### PR TITLE
Fix: Correct media resizing to exact dimensions

### DIFF
--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -140,7 +140,8 @@ pub fn resize_media(selected_dirs: &[PathBuf], size: (u32, u32)) -> Result<()> {
 
                 if IMAGE_EXTENSIONS.contains(&ext_lower.as_str()) {
                     let img = image::open(path)?;
-                    let resized_img = img.thumbnail(size.0, size.1);
+                    let resized_img =
+                        img.resize_exact(size.0, size.1, image::imageops::FilterType::Triangle);
                     resized_img.save(path)?;
                 } else if VIDEO_EXTENSIONS.contains(&ext_lower.as_str()) {
                     let temp_path = path.with_extension("resized.mp4");
@@ -156,10 +157,7 @@ pub fn resize_media(selected_dirs: &[PathBuf], size: (u32, u32)) -> Result<()> {
 
 fn resize_video(from: &Path, to: &Path, size: (u32, u32)) -> anyhow::Result<()> {
     let (width, height) = size;
-    let vf_param = format!(
-        "scale=w={}:h={}:force_original_aspect_ratio=decrease",
-        width, height
-    );
+    let vf_param = format!("scale=w={}:h={}", width, height);
 
     let status = Command::new("ffmpeg")
         .arg("-i")


### PR DESCRIPTION
The `test_full_preprocessing_pipeline` integration test was failing because the media resizing logic preserved the original aspect ratio, while the test asserted for exact dimensions (448x448).

This change modifies the `resize_media` function in `src/prelude.rs`:
- For images, `image::DynamicImage::thumbnail` is replaced with `resize_exact` to ignore the aspect ratio and resize to the precise dimensions.
- For videos, the `ffmpeg` scale filter is updated from `scale=w={w}:h={h}:force_original_aspect_ratio=decrease` to `scale=w={w}:h={h}` to enforce exact scaling.

These changes ensure that both images and videos are resized to the exact dimensions required by the test, which now passes successfully.