### PR TITLE
feat: Add ASCII art preview for images and videos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,11 +38,10 @@ indexmap = "2.7.1"
 futures = "0.3.31"
 ffmpeg-next = "8.0.0"
 num_cpus = "1.16.0"
-
 tokio = { version = "1.43.0", features = ["full"], optional = true }
 tokio-stream = { version = "0.1.17", optional = true }
 futures-batch = { version = "0.7.0", optional = true }
-ratatui = { version = "0.29.0", optional = true }
+ratatui = { version = "0.29.0", optional = true, features = ["macros"] }
 crossterm = { version = "0.29.0", optional = true }
 rusqlite = { version = "0.37.0", features = ["bundled"], optional = true }
 sha2 = { version = "0.10.8", optional = true }

--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -6,6 +6,7 @@
 
 use anyhow::Result;
 use crossterm::event::{self, Event, KeyCode, KeyEventKind};
+use image::DynamicImage;
 use ratatui::{backend::Backend, Terminal};
 use sha2::{Digest, Sha256};
 use std::{
@@ -37,6 +38,7 @@ pub enum ProgressUpdate {
     Message(String),
     Progress(f64),
     Error(String),
+    Frame(DynamicImage),
     Complete,
 }
 
@@ -48,6 +50,7 @@ pub struct AppConfig {
     pub video_path: String,
     pub threshold: f32,
     pub batch_size: usize,
+    pub show_ascii_art: bool,
 }
 
 /// Represents the different screens in the TUI.
@@ -69,6 +72,7 @@ pub enum MenuItem {
     VideoPath,
     Threshold,
     BatchSize,
+    ShowAsciiArt,
     Start,
 }
 
@@ -87,6 +91,8 @@ pub struct App {
     pub suggested_dirs: Vec<PathBuf>,
     pub selected_dirs: Vec<PathBuf>,
     pub suggestion_index: usize,
+    pub show_ascii_art: bool,
+    pub current_frame: Option<DynamicImage>,
 }
 
 impl Default for App {
@@ -99,6 +105,7 @@ impl Default for App {
                 video_path: "./videos".to_string(),
                 threshold: 0.5,
                 batch_size: 1,
+                show_ascii_art: false,
             },
             current_screen: CurrentScreen::SuggestingDirs,
             currently_editing: None,
@@ -108,6 +115,7 @@ impl Default for App {
                 MenuItem::VideoPath,
                 MenuItem::Threshold,
                 MenuItem::BatchSize,
+                MenuItem::ShowAsciiArt,
                 MenuItem::Start,
             ],
             menu_index: 0,
@@ -119,6 +127,8 @@ impl Default for App {
             suggested_dirs,
             selected_dirs: Vec::new(),
             suggestion_index: 0,
+            show_ascii_art: false,
+            current_frame: None,
         }
     }
 }
@@ -146,6 +156,9 @@ impl App {
                         self.is_error = true;
                         self.current_screen = CurrentScreen::Finished;
                         self.rx = None;
+                    }
+                    ProgressUpdate::Frame(frame) => {
+                        self.current_frame = Some(frame);
                     }
                     ProgressUpdate::Complete => {
                         self.status_message = "Processing complete!".to_string();
@@ -238,12 +251,14 @@ impl App {
     /// Handles the selection of a menu item.
     fn handle_menu_selection(&mut self) {
         let current_item = self.menu_items[self.menu_index];
-        if current_item == MenuItem::Start {
-            self.start_processing();
-        } else if current_item == MenuItem::Model {
-            self.config.model = self.config.model.next();
-        } else {
-            self.start_editing(current_item);
+        match current_item {
+            MenuItem::Start => self.start_processing(),
+            MenuItem::Model => self.config.model = self.config.model.next(),
+            MenuItem::ShowAsciiArt => {
+                self.show_ascii_art = !self.show_ascii_art;
+                self.config.show_ascii_art = self.show_ascii_art;
+            }
+            _ => self.start_editing(current_item),
         }
     }
 
@@ -347,8 +362,24 @@ async fn run_full_process(
 ) -> Result<()> {
     prepare_media_files(&selected_dirs, &tx).await?;
     let (pipe, rating_model, db) = initialize_pipeline_and_db(&config, &tx).await?;
-    process_images(&selected_dirs, &pipe, &rating_model, &db, &tx).await?;
-    process_videos(&selected_dirs, &pipe, &rating_model, &db, &tx).await?;
+    process_images(
+        &selected_dirs,
+        &pipe,
+        &rating_model,
+        &db,
+        &tx,
+        config.show_ascii_art,
+    )
+    .await?;
+    process_videos(
+        &selected_dirs,
+        &pipe,
+        &rating_model,
+        &db,
+        &tx,
+        config.show_ascii_art,
+    )
+    .await?;
     tx.send(ProgressUpdate::Complete).await?;
     Ok(())
 }
@@ -419,6 +450,7 @@ async fn process_images(
     rating_model: &Arc<Mutex<RatingModel>>,
     db: &Arc<Mutex<Database>>,
     tx: &mpsc::Sender<ProgressUpdate>,
+    show_ascii_art: bool,
 ) -> Result<()> {
     let mut image_files = Vec::new();
     for dir in selected_dirs {
@@ -436,6 +468,10 @@ async fn process_images(
         .await?;
         for (i, image_file) in image_files.into_iter().enumerate() {
             let img = image::open(&image_file)?;
+            if show_ascii_art {
+                // We don't care if this fails, it just means the UI closed.
+                let _ = tx.send(ProgressUpdate::Frame(img.clone())).await;
+            }
             let rating = rating_model.lock().unwrap().rate(&img)?;
             let result = pipe.lock().unwrap().predict(img, None)?;
             let simple_result = TaggingResultSimple::from(result);
@@ -466,6 +502,7 @@ async fn process_videos(
     rating_model: &Arc<Mutex<RatingModel>>,
     db: &Arc<Mutex<Database>>,
     tx: &mpsc::Sender<ProgressUpdate>,
+    show_ascii_art: bool,
 ) -> Result<()> {
     let mut video_files = Vec::new();
     for dir in selected_dirs {
@@ -482,7 +519,16 @@ async fn process_videos(
         )))
         .await?;
         for (i, video_file) in video_files.into_iter().enumerate() {
-            video::process_video(&video_file, pipe, rating_model, db, get_hash).await?;
+            video::process_video(
+                &video_file,
+                pipe,
+                rating_model,
+                db,
+                get_hash,
+                tx,
+                show_ascii_art,
+            )
+            .await?;
             tx.send(ProgressUpdate::Progress(
                 0.625 + 0.375 * (i + 1) as f64 / total_videos as f64,
             ))

--- a/src/app/ascii.rs
+++ b/src/app/ascii.rs
@@ -1,0 +1,36 @@
+use image::{imageops::FilterType, DynamicImage, GenericImageView};
+use ratatui::layout::Rect;
+
+const ASCII_CHARS: [char; 11] = [' ', '.', ':', '-', '=', '+', '*', '#', '%', '@', '$'];
+
+/// Converts an image to ASCII art that fits within the given dimensions.
+pub fn create_ascii_art(image: &DynamicImage, area: Rect) -> String {
+    if area.width == 0 || area.height < 2 {
+        return String::new();
+    }
+
+    // Adjust height to compensate for character aspect ratio in terminals
+    let ascii_height = (area.height as f32 / 2.0).round() as u32;
+    if ascii_height == 0 {
+        return String::new();
+    }
+
+    let width = area.width as u32;
+    let height = ascii_height;
+
+    let resized_image = image.resize_exact(width, height, FilterType::Nearest);
+    let mut ascii_art = String::new();
+
+    for y in 0..resized_image.height() {
+        for x in 0..resized_image.width() {
+            let pixel = resized_image.get_pixel(x, y);
+            let gray =
+                (pixel[0] as f32 * 0.299 + pixel[1] as f32 * 0.587 + pixel[2] as f32 * 0.114) as u8;
+            let char_index = (gray as f32 / 255.0 * (ASCII_CHARS.len() - 1) as f32).round() as usize;
+            ascii_art.push(ASCII_CHARS[char_index]);
+        }
+        ascii_art.push('\n');
+    }
+
+    ascii_art
+}

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -1,5 +1,6 @@
 mod app;
 mod args;
+mod ascii;
 mod db;
 mod file;
 mod tag;

--- a/src/app/ui.rs
+++ b/src/app/ui.rs
@@ -1,4 +1,7 @@
-use crate::app::{App, CurrentScreen, MenuItem};
+use crate::{
+    app::{App, CurrentScreen, MenuItem},
+    ascii,
+};
 use ratatui::{
     prelude::*,
     widgets::{Block, Borders, Clear, Gauge, List, ListItem, Paragraph},
@@ -38,7 +41,31 @@ pub fn draw(f: &mut Frame, app: &App) {
                 .split(chunks[1]);
 
             render_menu(f, app, main_chunks[0]);
-            f.render_widget(Block::default().borders(Borders::ALL), main_chunks[1]);
+
+            if app.show_ascii_art {
+                let art = if let Some(frame) = &app.current_frame {
+                    // Subtract border size from the area
+                    let inner_area = main_chunks[1].inner(Margin {
+                        vertical: 1,
+                        horizontal: 1,
+                    });
+                    ascii::create_ascii_art(frame, inner_area)
+                } else {
+                    "Waiting for image...".to_string()
+                };
+
+                let ascii_art_widget = Paragraph::new(art)
+                    .block(Block::default().borders(Borders::ALL).title("ASCII Art"))
+                    .alignment(Alignment::Center);
+                f.render_widget(ascii_art_widget, main_chunks[1]);
+            } else {
+                f.render_widget(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .title("Preview (Enable ASCII Art in Menu)"),
+                    main_chunks[1],
+                );
+            }
 
             let footer_text = "Use ↑/↓ or j/k to navigate, ↩ to select/edit, 'q' to quit.";
             let footer = Paragraph::new(footer_text)
@@ -116,6 +143,9 @@ fn render_menu(f: &mut Frame, app: &App, area: Rect) {
                 MenuItem::InputPath => format!("Input Path: {}", config.input_path),
                 MenuItem::Threshold => format!("Threshold: {}", config.threshold),
                 MenuItem::BatchSize => format!("Batch Size: {}", config.batch_size),
+                MenuItem::ShowAsciiArt => {
+                    format!("Show ASCII Art: < {} >", if app.show_ascii_art { "On" } else { "Off" })
+                }
                 MenuItem::Start => "Start Processing".to_string(),
                 MenuItem::VideoPath => format!("Video Path: {}", config.video_path),
             };

--- a/src/app/video.rs
+++ b/src/app/video.rs
@@ -1,5 +1,4 @@
-use crate::db::Database;
-use crate::file::TaggingResultSimple;
+use crate::{app::ProgressUpdate, db::Database, file::TaggingResultSimple};
 use anyhow::Result;
 use eros::{pipeline::TaggingPipeline, rating::RatingModel};
 use futures::stream::{self, StreamExt};
@@ -9,6 +8,7 @@ use std::{
     path::{Path, PathBuf},
     sync::{Arc, Mutex},
 };
+use tokio::sync::mpsc;
 
 /// Supported video extensions.
 pub const VIDEO_EXTENSIONS: [&str; 4] = ["mp4", "mkv", "webm", "avi"];
@@ -58,53 +58,39 @@ pub async fn process_video(
     rating_model: &Arc<Mutex<RatingModel>>,
     db: &Arc<Mutex<Database>>,
     get_hash_fn: impl Fn(&Path) -> Result<String>,
+    tx: &mpsc::Sender<ProgressUpdate>,
+    show_ascii_art: bool,
 ) -> Result<()> {
-    println!("Processing video: {}", video_path.display());
-
-    // Create a temporary folder for frames
-    let _video_name = video_path.file_stem().and_then(|s| s.to_str()).unwrap_or("video");
-    let temp_frame_dir = format!("./temp");
-    fs::create_dir_all(&temp_frame_dir)?;
-
-    println!("  - Extracting frames to {}...", temp_frame_dir);
-
     // Extract frames every 3 seconds
-    let extracted_frame_paths = extract_frames(video_path, &temp_frame_dir)?;
-    println!("  - Extracted {} frames.", extracted_frame_paths.len());
+    let frame_images = extract_frames(video_path)?;
 
-    if extracted_frame_paths.is_empty() {
-        println!("  - No frames extracted, skipping video.");
-        fs::remove_dir_all(&temp_frame_dir)?;
+    if frame_images.is_empty() {
         return Ok(());
     }
 
-    // Run the AI tagger on all the frames
-    println!("  - Tagging and rating extracted frames...");
     let mut all_tags = Vec::new();
     let mut overall_rating = "sfw";
-    let frame_images: Vec<DynamicImage> = extracted_frame_paths
-        .iter()
-        .filter_map(|p| image::open(p).ok())
-        .collect();
 
-    if !frame_images.is_empty() {
-        for frame_image in &frame_images {
-            let rating = rating_model.lock().unwrap().rate(frame_image)?;
-            if rating.as_str() == "nsfw" {
-                overall_rating = "nsfw";
-                break;
+    for frame_image in frame_images {
+        if show_ascii_art {
+            if tx.send(ProgressUpdate::Frame(frame_image.clone())).await.is_err() {
+                // UI receiver has been dropped, so we can stop.
+                return Ok(());
             }
         }
 
-        let results = pipe
-            .lock()
-            .unwrap()
-            .predict_batch(frame_images.iter().collect(), None)?;
-        for result in results {
-            let simple_result = TaggingResultSimple::from(result);
-            if !simple_result.tags.is_empty() {
-                all_tags.extend(simple_result.tags.split(", ").map(|s| s.to_string()));
+        // Determine rating, stopping at the first NSFW frame
+        if overall_rating != "nsfw" {
+            let rating = rating_model.lock().unwrap().rate(&frame_image)?;
+            if rating.as_str() == "nsfw" {
+                overall_rating = "nsfw";
             }
+        }
+
+        let result = pipe.lock().unwrap().predict(frame_image, None)?;
+        let simple_result = TaggingResultSimple::from(result);
+        if !simple_result.tags.is_empty() {
+            all_tags.extend(simple_result.tags.split(", ").map(|s| s.to_string()));
         }
     }
 
@@ -113,31 +99,23 @@ pub async fn process_video(
     let hash = get_hash_fn(video_path)?;
     let size = fs::metadata(video_path)?.len();
 
-    {
-        let db_lock = db.lock().unwrap();
-        db_lock.save_video_tags(
-            video_path.to_str().unwrap(),
-            size,
-            &hash,
-            &tags_string,
-            overall_rating,
-        )?;
-        println!("  - Saved {} tags to the database.", all_tags.len());
+    let db_lock = db.lock().unwrap();
+    db_lock.save_video_tags(
+        video_path.to_str().unwrap(),
+        size,
+        &hash,
+        &tags_string,
+        overall_rating,
+    )?;
 
-        // Clean up the database by removing duplicate tags
-        db_lock.cleanup_video_tags(&hash)?;
-        println!("  - Cleaned up and deduplicated tags in the database.");
-    }
-
-    // Clean up temporary frames
-    fs::remove_dir_all(&temp_frame_dir)?;
-    println!("  - Removed temporary frame directory.");
+    // Clean up the database by removing duplicate tags
+    db_lock.cleanup_video_tags(&hash)?;
 
     Ok(())
 }
 
 /// Extracts frames from a video at a 3-second interval.
-fn extract_frames(video_path: &Path, output_dir: &str) -> Result<Vec<PathBuf>> {
+fn extract_frames(video_path: &Path) -> Result<Vec<DynamicImage>> {
     ffmpeg_next::init().unwrap();
     let mut ictx = ffmpeg_next::format::input(&video_path)?;
     let input = ictx
@@ -165,8 +143,7 @@ fn extract_frames(video_path: &Path, output_dir: &str) -> Result<Vec<PathBuf>> {
     )?;
 
     let mut frame_count = 0i64;
-    let mut saved_frame_count = 0;
-    let mut extracted_frame_paths = Vec::new();
+    let mut extracted_frames = Vec::new();
 
     for (stream, packet) in ictx.packets() {
         if stream.index() == video_stream_index {
@@ -176,10 +153,7 @@ fn extract_frames(video_path: &Path, output_dir: &str) -> Result<Vec<PathBuf>> {
                 if frame_count % frame_interval == 0 {
                     let mut rgb_frame = ffmpeg_next::util::frame::video::Video::empty();
                     scaler.run(&decoded, &mut rgb_frame)?;
-                    let frame_path =
-                        PathBuf::from(output_dir).join(format!("frame_{:05}.png", saved_frame_count));
 
-                    // --- FIX IS HERE ---
                     let width = rgb_frame.width() as usize;
                     let height = rgb_frame.height() as usize;
                     let stride = rgb_frame.stride(0) as usize;
@@ -187,10 +161,8 @@ fn extract_frames(video_path: &Path, output_dir: &str) -> Result<Vec<PathBuf>> {
 
                     let mut image_data = Vec::with_capacity(width * height * 3);
                     if stride == width * 3 {
-                        // No padding, can copy directly
                         image_data.extend_from_slice(data);
                     } else {
-                        // Copy row by row to remove padding
                         for y in 0..height {
                             let start = y * stride;
                             let end = start + width * 3;
@@ -198,21 +170,17 @@ fn extract_frames(video_path: &Path, output_dir: &str) -> Result<Vec<PathBuf>> {
                         }
                     }
 
-                    image::ImageBuffer::<image::Rgb<u8>, _>::from_raw(
+                    if let Some(image_buffer) = image::ImageBuffer::<image::Rgb<u8>, _>::from_raw(
                         width as u32,
                         height as u32,
                         image_data,
-                    )
-                    .expect("Failed to create image buffer from frame data")
-                    .save(&frame_path)?;
-                    // --- END OF FIX ---
-
-                    extracted_frame_paths.push(frame_path);
-                    saved_frame_count += 1;
+                    ) {
+                        extracted_frames.push(DynamicImage::ImageRgb8(image_buffer));
+                    }
                 }
                 frame_count += 1;
             }
         }
     }
-    Ok(extracted_frame_paths)
+    Ok(extracted_frames)
 }


### PR DESCRIPTION
This commit introduces a new feature that displays an ASCII art representation of the image or video frame currently being processed in the terminal UI.

Key changes:
- Added a toggleable "Show ASCII Art" option in the main menu.
- Implemented a self-contained ASCII art generator in `src/app/ascii.rs` to avoid dependency conflicts.
- Refactored the video processing pipeline in `src/app/video.rs` to extract and process frames in memory, improving performance and enabling real-time frame previews.
- Modified the UI in `src/app/ui.rs` to render the ASCII art in a dedicated pane, with the level of detail adjusting to the terminal size.
- Updated the application state in `src/app/app.rs` to manage the feature's configuration and the current frame data.